### PR TITLE
Remove a regra no-plusplus 

### DIFF
--- a/config.json
+++ b/config.json
@@ -58,6 +58,7 @@
     "no-param-reassign": ["off"],
     "consistent-return": ["off"],
     "no-undef": ["off"],
+    "no-plusplus": ["off"],
     "max-len": [
       "error",
       {


### PR DESCRIPTION
# Alteração de regra

Remove a regra `no-pluspls`.

## Racional
Apesar de ser uma regra com uma boa explicação filosófica, na prática, não faz tanto sentido para nosso linter. 