### PR TITLE
chore: disable proptypes

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -31,6 +31,7 @@ module.exports = {
     '@typescript-eslint/no-floating-promises': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
     'import/extensions': 'off',
-    "import/no-unresolved": [2, { "caseSensitiveStrict": true }]
+    "import/no-unresolved": [2, { "caseSensitiveStrict": true }],
+    "react/prop-types": "off",
   },
 };


### PR DESCRIPTION
Ao criar um componente sem tipar suas props, estava sendo mostrando um aviso de prop-types que atrapalhava a leitura dos avisos do próprio ts.